### PR TITLE
Fixes

### DIFF
--- a/sql/description.sql
+++ b/sql/description.sql
@@ -2,11 +2,13 @@ select *,
     balance / 100.0 as eur_balance
 from (
         select *,
-            amount * iif(`from` = 'NULL', 1, -1) / 100.0 as eur_with_sign,
-            sum(amount * iif(`from` = 'NULL', 1, -1)) over (
+            amount * iif(`from` = 'NULL', 1, iif(`to` = 'NULL', -1, 0)) / 100.0 as eur_with_sign,
+            sum(
+                amount * iif(`from` = 'NULL', 1, iif(`to` = 'NULL', -1, 0))
+            ) over (
                 order by date(`date`),
                     id
             ) as balance
         from transactions
-        where description like 'bbq cumple rafa%'
+        where `description` like 'placeholder%'
     );

--- a/src/cli/delete.ts
+++ b/src/cli/delete.ts
@@ -34,7 +34,7 @@ const del = zodCommand({
 				await db.delete(transactions).where(inArray(transactions.id, ids))
 		} else {
 			const txs = await db.query.transactions.findMany({
-				orderBy: desc(transactions.date),
+				orderBy: [desc(transactions.date), desc(transactions.id)],
 				limit,
 			})
 			const [header, ...rows] = toTable(txs.map(formatTx))


### PR DESCRIPTION
### Fixed

- Remove internal txs balances from balance calculation in `description.sql`.
- Sort delete options by `date` **and** `id`. Previously, they were only ordered by date and it could be quite messy when there were a lot of transactions of the same date.