### PR TITLE
Fixes

### DIFF
--- a/src/cli/tags.ts
+++ b/src/cli/tags.ts
@@ -84,7 +84,7 @@ const tags = zodCommand({
 				return [
 					tag || '(no tag)',
 					tableNum(stats.earned),
-					tableNum(stats.spent, { invColor: true }),
+					tableNum(stats.spent, { inv: true }),
 					tableNum(stats.net),
 					`${percentage.toFixed(1)}%`,
 				]
@@ -101,7 +101,7 @@ const tags = zodCommand({
 		totalTable.push([
 			'TOTAL',
 			tableNum(totals.earned.toFixed(2)),
-			tableNum(totals.spent.toFixed(2), { invColor: true }),
+			tableNum(totals.spent.toFixed(2), { inv: true }),
 			tableNum(totals.net.toFixed(2)),
 			'100%',
 		])

--- a/src/cli/txs.ts
+++ b/src/cli/txs.ts
@@ -6,7 +6,7 @@ import db from '#/db/index.js'
 import { transactions } from '#/db/schema.js'
 import { orderBy_column } from '#/utils/command-options.js'
 import { csvTable } from '#/utils/csv-table.js'
-import { formatDate, tableNum } from '#/utils/index.js'
+import { formatDate, isTruthy, tableNum } from '#/utils/index.js'
 import * as zs from '#/utils/z-schemas.js'
 
 function insertDividers(txs: zs.Transaction[]) {
@@ -45,8 +45,11 @@ const txs = zodCommand({
 		dividers: zs.flag.describe('Include month dividers'),
 		summary: zs.flag.describe('Show a balance summary at the end'),
 		csv: zs.flag.describe('Format the output in CSV'),
+		pretty: zs.flag.describe(
+			'Use pretty format that can be used to show results to non-technical people',
+		),
 	},
-	async action({ account }, { orderBy, dividers, summary, csv }) {
+	async action({ account }, { orderBy, dividers, summary, csv, pretty }) {
 		const acc = account ?? 'NULL'
 		const txs = await db.query.transactions.findMany({
 			where: or(eq(transactions.from, acc), eq(transactions.to, acc)),
@@ -54,15 +57,15 @@ const txs = zodCommand({
 		})
 		let balance = 0
 		const head = [
-			'Id',
+			!pretty && 'Id',
 			'Date',
 			'Amount',
-			'From',
-			'To',
+			!pretty && 'From',
+			!pretty && 'To',
 			'Description',
 			'Tag',
 			'Balance',
-		]
+		].filter(isTruthy)
 		const table = new Table({ head, style: { head: ['cyan'] } })
 
 		if (dividers || summary) insertDividers(txs)
@@ -71,15 +74,15 @@ const txs = zodCommand({
 			const neg = (!account ? tx.to : tx.from) === acc
 			balance += neg ? -amount : amount
 			return [
-				tx.id,
+				!pretty && tx.id,
 				formatDate(tx.date),
-				tableNum(tx.amount, { invColor: neg }),
-				tx.from,
-				tx.to,
-				tx.description,
-				tx.tag,
+				tableNum(tx.amount, { inv: neg, invSign: pretty }),
+				!pretty && tx.from,
+				!pretty && tx.to,
+				tx.description ?? ' ',
+				tx.tag ?? ' ',
 				tableNum(balance),
-			]
+			].filter(isTruthy)
 		})
 		table.push(...rows)
 		console.log(csv ? csvTable(table, { delimeter: ';' }) : table.toString())

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,16 +5,17 @@ import { z } from 'zod'
 import type { Transaction } from '#/utils/z-schemas.js'
 
 interface FormatNumOptions {
-	invColor: boolean
+	inv?: boolean
+	invSign?: boolean
 }
 
 export const formatNum = (
 	num: number | string,
-	{ invColor }: FormatNumOptions = { invColor: false },
+	{ inv = false, invSign = false }: FormatNumOptions = {},
 ) => {
 	const n = typeof num === 'string' ? parseFloat(num) : num
-	const s = n.toFixed(2)
-	const x = n * (invColor ? -1 : 1)
+	const s = (n * (invSign && inv ? -1 : 1)).toFixed(2)
+	const x = n * (inv ? -1 : 1)
 	return x < 0 ? chalk.red(s) : x > 0 ? chalk.green(s) : chalk.yellow(s)
 }
 
@@ -27,6 +28,10 @@ export function tableNum(num: number | string, opts?: FormatNumOptions) {
 
 export const typedObjectKeys = <T extends object>(obj: T) =>
 	Object.keys(obj) as [keyof T, ...(keyof T)[]]
+
+export const isTruthy = <T>(
+	value: T | 0 | '' | null | undefined | false,
+): value is T => Boolean(value)
 
 export const formatDate = (date: Date) => date.toISOString().split('T')[0]
 

--- a/src/utils/z-schemas.ts
+++ b/src/utils/z-schemas.ts
@@ -29,11 +29,15 @@ export const commasArray = <Output, Def extends z.ZodTypeDef, Input>(
 
 export const date = z
 	.string()
-	.regex(/^(\d{4}-)?\d{1,2}-\d{1,2}/)
+	.regex(/^(?:\d{4}-)?(?:\d{1,2}-)?\d{1,2}/)
 	.transform((v) => {
 		const spl = v.split('-').map((v) => v.padStart(2, '0'))
-		const withYear = spl.length === 3 ? spl : [new Date().getFullYear(), ...spl]
-		return withYear.join('-')
+		const date = new Date()
+		return [
+			spl.at(-3) ?? date.getFullYear(),
+			spl.at(-2) ?? date.getMonth() + 1,
+			spl.at(-1),
+		].join('-')
 	})
 	.pipe(
 		z


### PR DESCRIPTION
### Added

- `--pretty` option to the `export` command. It returns data in a simplified format than can be more easily understood by third parties.
- Day-only date input. If a single number is input in a date field, it will be assumed as the day and the month and year will default to the current one.