### PR TITLE
Templates v2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,8 @@
 		"repo",
 		"sql",
 		"delete",
-		"balance"
+		"balance",
+		"conf"
 	],
 	"[typescript]": {
 		"editor.defaultFormatter": "biomejs.biome"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
 	"conventionalCommits.scopes": [
 		"export",
 		"dev",
-		"template",
+		"worflow",
 		"args",
 		"txs",
 		"tags",

--- a/src/cli/get-conf/index.ts
+++ b/src/cli/get-conf/index.ts
@@ -1,0 +1,7 @@
+import { zodCommand } from 'zod-commander/zod4'
+import templates from './templates.js'
+
+export default zodCommand({
+	name: 'get-conf',
+	description: 'Print details about the configuration',
+}).addCommand(templates)

--- a/src/cli/get-conf/templates.ts
+++ b/src/cli/get-conf/templates.ts
@@ -1,0 +1,19 @@
+import z from 'zod'
+import { zodCommand } from 'zod-commander/zod4'
+import templates from '#/configs/templates.js'
+import { typedObjectKeys } from '#/utils/index.js'
+
+export default zodCommand({
+	name: 'templates',
+	description: 'Print the available template details',
+	args: {
+		template: z
+			.enum(typedObjectKeys(templates))
+			.optional()
+			.describe('The name of the template to print. Omit to print all.'),
+	},
+	async action({ template }) {
+		const res = template ? templates[template] : templates
+		console.dir(res, { depth: null })
+	},
+})

--- a/src/cli/insert.ts
+++ b/src/cli/insert.ts
@@ -1,10 +1,19 @@
+import z from 'zod'
 import { zodCommand } from 'zod-commander/zod4'
+import templates from '#/configs/templates.js'
 import db from '#/db/index.js'
 import { transactions } from '#/db/schema.js'
-import { zodObjectInput } from '#/utils/index.js'
+import { transactionStrOpts } from '#/utils/command-options.js'
+import { typedObjectKeys, zodObjectInput } from '#/utils/index.js'
 import * as zs from '#/utils/z-schemas.js'
-
 import { makeBalancesTable } from './balance.js'
+
+type TxKey = keyof zs.InsertTx
+type Template = {
+	default?: Partial<Record<TxKey, string>>
+	readonly?: Partial<Record<TxKey, string>>
+}
+export type Templates = Record<string, Template>
 
 export const afterInsert = async (
 	transactions: Pick<zs.Transaction, 'from' | 'to'>[],
@@ -17,8 +26,19 @@ export const afterInsert = async (
 const insert = zodCommand({
 	name: 'insert',
 	description: 'Insert a transaction into the money database',
-	async action() {
-		const transaction = await zodObjectInput(zs.transaction.shape)
+	opts: {
+		...transactionStrOpts,
+		template: z
+			.enum(typedObjectKeys(templates))
+			.optional()
+			.describe('t;The name of the template to use to prefill the transaction'),
+	},
+	async action(_, { template, ...tx }) {
+		const tp = template && templates[template]
+		const transaction = await zodObjectInput(zs.transaction.shape, {
+			default: tp?.default,
+			readonly: { ...tp?.readonly, ...tx },
+		})
 		await db.insert(transactions).values(transaction)
 		await afterInsert([transaction])
 	},

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -1,49 +1,37 @@
 import { confirm } from '@inquirer/prompts'
 import { z } from 'zod'
 import { zodCommand } from 'zod-commander/zod4'
-import templates from '#/configs/templates.js'
+import workflows from '#/configs/workflows.js'
 import db from '#/db/index.js'
 import { transactions } from '#/db/schema.js'
 import { transactionOpts } from '#/utils/command-options.js'
 import { typedObjectKeys } from '#/utils/index.js'
 import type * as zs from '#/utils/z-schemas.js'
-
 import { afterInsert } from './insert.js'
 
-type TemplateReturn = Omit<zs.InsertTx, 'date'> & Partial<zs.InsertTx>
-export type Templates = Record<
-	string,
-	| TemplateReturn
-	| TemplateReturn[]
-	| ((tx: Partial<zs.InsertTx>) => Promise<TemplateReturn[]>)
->
+type WorkflowReturn = Omit<zs.InsertTx, 'date'> & Partial<zs.InsertTx>
+type Workflow = (tx: Partial<zs.InsertTx>) => Promise<WorkflowReturn[]>
+export type Workflows = Record<string, Workflow>
 
 const getTxs = async (
-	template: keyof typeof templates,
+	workflow: keyof typeof workflows,
 	tx: Partial<zs.InsertTx> & Pick<zs.InsertTx, 'date'>,
 ): Promise<zs.InsertTx[]> => {
-	const temp = templates[template]
-	const txs: TemplateReturn[] =
-		typeof temp === 'function'
-			? await temp(tx)
-			: (Array.isArray(temp) ? temp : [temp]).map((t) => ({
-					...t,
-					...tx,
-				}))
+	const txs: WorkflowReturn[] = await workflows[workflow](tx)
 	return txs.map((newTx) => ({ date: tx.date, ...newTx }))
 }
 
-const template = zodCommand({
-	name: 'template',
-	description: 'Insert one or more transactions using one a template',
+const workflow = zodCommand({
+	name: 'workflow',
+	description: 'Insert one or more transactions using one a workflow',
 	args: {
-		template: z
-			.enum(typedObjectKeys(templates))
-			.describe('The template to use'),
+		workflow: z
+			.enum(typedObjectKeys(workflows))
+			.describe('The workflow to use'),
 	},
 	opts: transactionOpts,
-	action: async ({ template }, tx) => {
-		const txs = await getTxs(template, tx)
+	action: async ({ workflow }, tx) => {
+		const txs = await getTxs(workflow, tx)
 		console.table(txs)
 		const ans = await confirm({
 			message: 'Do you want to insert these transactions?',
@@ -54,4 +42,4 @@ const template = zodCommand({
 	},
 })
 
-export default template
+export default workflow

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander'
 import balance from './cli/balance.js'
 import del from './cli/delete.js'
 import exp from './cli/export.js'
+import getConf from './cli/get-conf/index.js'
 import imp from './cli/import.js'
 import insert from './cli/insert.js'
 import tags from './cli/tags.js'
@@ -21,6 +22,7 @@ program
 	.addCommand(balance)
 	.addCommand(del)
 	.addCommand(exp)
+	.addCommand(getConf)
 	.addCommand(imp)
 	.addCommand(insert)
 	.addCommand(tags)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ import exp from './cli/export.js'
 import imp from './cli/import.js'
 import insert from './cli/insert.js'
 import tags from './cli/tags.js'
-import template from './cli/template.js'
 import test from './cli/test.js'
 import txs from './cli/txs.js'
+import workflow from './cli/workflow.js'
 
 const program = new Command()
 
@@ -24,7 +24,7 @@ program
 	.addCommand(imp)
 	.addCommand(insert)
 	.addCommand(tags)
-	.addCommand(template)
+	.addCommand(workflow)
 	.addCommand(test)
 	.addCommand(txs)
 	.parseAsync(process.argv)

--- a/src/utils/command-options.ts
+++ b/src/utils/command-options.ts
@@ -28,3 +28,11 @@ export const transactionOpts = {
 		.describe('Override transaction description'),
 	tag: zs.tag.optional().describe('Override transaction tag'),
 }
+
+// these should have no defaults, as they are used for overrides
+export const transactionStrOpts = {
+	...transactionOpts,
+	date: transactionOpts.date.prefault(undefined).transform(formatDate),
+	amount: transactionOpts.amount.transform((v) => v?.toString()),
+	tag: transactionOpts.tag.transform((v) => v ?? ''),
+} satisfies Record<string, z.ZodType<string | undefined>>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -71,6 +71,27 @@ const zodIn = (zod: z.ZodTypeAny): z.core.$ZodType => {
 		: core
 }
 
+export const readonlyInput = (message: string, value: string | undefined) =>
+	input(
+		{
+			message,
+			required: true,
+			default: value,
+			prefill: 'editable',
+			theme: {
+				prefix: styleText(['green', 'dim'], '🟰'),
+			},
+		},
+		{ signal: AbortSignal.timeout(0) },
+	).catch((e) => {
+		if (e.name === 'AbortPromptError') return value
+		throw e
+	})
+
+type ZodInputOptions = {
+	default?: string
+	readonly?: boolean
+}
 export const zodInput = async <Output>(
 	message: string,
 	zod: z.ZodType<Output, string | undefined>,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { styleText } from 'node:util'
 import { input, search } from '@inquirer/prompts'
 import chalk from 'chalk'
 import Fuse from 'fuse.js'
@@ -95,44 +96,56 @@ type ZodInputOptions = {
 export const zodInput = async <Output>(
 	message: string,
 	zod: z.ZodType<Output, string | undefined>,
+	opts: ZodInputOptions = {},
 ) => {
 	const zIn = zodIn(zod)
-	if (!(zIn instanceof z.ZodEnum))
-		return zod.parse(
-			await input({
-				message,
-				validate: z2v(zod),
-				required: !zod.isOptional(),
-				default: zodDefault(zod),
-			}),
-		)
+	const def = opts.default ?? zodDefault(zod)
+	const validate = z2v(zod)
 
-	return zod.parse(
-		await search({
-			message,
-			validate: z2v(zod),
-			source: (input) => {
-				const values = zIn.options.map(String)
-				const def = zodDefault(zod)
-				if (!input)
-					return values
-						.slice()
-						.sort((a, b) => (a === def ? -1 : b === def ? 1 : 0))
-						.map((v) => ({ value: v }))
+	const res = opts.readonly
+		? readonlyInput(message, def)
+		: zIn instanceof z.ZodEnum
+			? search({
+					message,
+					validate,
+					source: (input) => {
+						const values = zIn.options.map(String)
+						if (!input)
+							return values
+								.slice()
+								.sort((a, b) => (a === def ? -1 : b === def ? 1 : 0))
+								.map((v) => ({ value: v }))
 
-				const fuse = new Fuse(values)
-				return fuse.search(input).map(({ item }) => ({ value: item }))
-			},
-		}),
-	)
+						const fuse = new Fuse(values)
+						return fuse.search(input).map(({ item }) => ({ value: item }))
+					},
+				})
+			: input({
+					message,
+					validate,
+					required: !zod.isOptional(),
+					default: def,
+				})
+
+	return zod.parse(await res)
 }
 
+type ZodObjectInputOptions<K extends string = string> = {
+	default?: Partial<Record<K, string>>
+	readonly?: Partial<Record<K, string>>
+}
 export const zodObjectInput = async <
-	S extends Record<string, z.ZodType<unknown, string | undefined>>,
+	K extends string,
+	S extends Record<K, z.ZodType<unknown, string | undefined>>,
 >(
 	shape: S,
+	{ readonly = {}, default: def = {} }: ZodObjectInputOptions<K> = {},
 ) => {
 	const obj: Record<string, unknown> = {}
-	for (const key in shape) obj[key] = await zodInput(key, shape[key])
+	for (const key in shape)
+		obj[key] = await zodInput(key, shape[key], {
+			default: readonly[key] ?? def[key],
+			readonly: key in readonly && readonly[key as unknown as K] !== undefined,
+		})
 	return obj as z.infer<z.ZodObject<S>>
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,9 @@
 		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
 		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
 		// "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-		// "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+		"types": [
+			"node"
+		] /* Specify type package names to be included without being referenced in a source file. */,
 		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
 		// "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
 		// "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
## CLI

### Added

- Add a `get-conf templates` command for inspecting template configuration.
- Add template support to the `input` command.
- Add `readonlyInput` for read-only prompt handling.
- Extend `zodInput` with `default` and `readonly` options.
- Rename the old template CLI implementation to `workflows`.

### Changed

#### Codebase changes

- Add Node type definitions to `tsconfig.json`.
- Update editor settings to match the new CLI structure.